### PR TITLE
Add @Input to data error validation message

### DIFF
--- a/src/inputs/input-validate.directive.ts
+++ b/src/inputs/input-validate.directive.ts
@@ -7,6 +7,8 @@ import { Directive, Input, ElementRef, Renderer, OnInit, HostListener } from '@a
 export class InputValidateDirective implements OnInit {
 
   @Input() public value = '';
+  @Input() public dataError = 'wrong';
+  @Input() public dataSuccess = 'right';
   public wrongTextContainer: any;
   public rightTextContainer: any;
 
@@ -19,15 +21,14 @@ export class InputValidateDirective implements OnInit {
     this.wrongTextContainer = this._renderer.createElement(this._elRef.nativeElement.parentElement, 'span');
     this._renderer.setElementClass(this.wrongTextContainer, 'inputVal', true);
     this._renderer.setElementClass(this.wrongTextContainer, 'text-danger', true);
-    this.wrongTextContainer.innerHTML = 'wrong';
+    this.wrongTextContainer.innerHTML = this.dataError;
     this._renderer.setElementStyle(this.wrongTextContainer, 'visibility', 'hidden');
 
     this.rightTextContainer = this._renderer.createElement(this._elRef.nativeElement.parentElement, 'span');
     this._renderer.setElementClass(this.rightTextContainer, 'inputVal', true);
     this._renderer.setElementClass(this.rightTextContainer, 'text-success', true);
-    this.rightTextContainer.innerHTML = 'right';
+    this.rightTextContainer.innerHTML = this.dataSuccess;
     this._renderer.setElementStyle(this.rightTextContainer, 'visibility', 'hidden');
-
   }
 
 


### PR DESCRIPTION
Hello,

Currently the validation not is at all 'angular-ish' since you cannot bind data to data-error and data-success.

This is not enough for most cases since you might need validation in different lang for exemple.
This fix allow [dataError] and [dataSuccess] message to be added 

Please review and merge if that's ok for you