### PR TITLE
removed 'BrowserAnimationsModule'

### DIFF
--- a/projects/angular-bootstrap-md/src/lib/sticky-header/sticky-header.module.ts
+++ b/projects/angular-bootstrap-md/src/lib/sticky-header/sticky-header.module.ts
@@ -7,8 +7,7 @@ import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
   declarations: [StickyHeaderDirective],
   exports: [StickyHeaderDirective],
   imports: [
-    CommonModule,
-    BrowserAnimationsModule
+    CommonModule
   ]
 })
 export class StickyHeaderModule {


### PR DESCRIPTION
Hey guys,

i think its an bug.

Had this error after a merge:
`Error: BrowserModule has already been loaded.`

After a day of search, i found the bug.