### PR TITLE
Update README for Angular 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ xxxxxxxxxxx
 <h1 align="center">Angular Bootstrap with Material Design</h1>
 
 <p align="center">
-  Built with <b>Angular 7, Bootstrap 4 and TypeScript</b>. CLI version available. Absolutely no jQuery.
+  Built with <b>Angular 8, Bootstrap 4 and TypeScript</b>. CLI version available. Absolutely no jQuery.
 </p>
 <p align="center">
   <b>400+</b> material UI elements, <b>600+</b> material icons, <b>74</b> CSS animations, TypeScript modules, SASS files and many more.
@@ -62,19 +62,19 @@ ________
 
 # Version
 
-- Angular 7
-- Angular CLI 7
+- Angular 8
+- Angular CLI 8
 
 # Quick start
 
-- Clone following repo:  
+- Clone following repo:
 ```javascript
 git clone https://github.com/mdbootstrap/Angular-Bootstrap-with-Material-Design.git .
-``` 
-note "." at the end. It will clone files directly into current folder. 
+```
+note "." at the end. It will clone files directly into current folder.
 - Run `npm i`
 - Run `npm start`
-- Voilà! Open browser and visit http://localhost:4200 
+- Voilà! Open browser and visit http://localhost:4200
 
 Now you can navigate to [our documentation](https://mdbootstrap.com/docs/angular/), pick any component and place within your project.
 
@@ -131,7 +131,7 @@ rename /src/styles.css to styles.scss
 
 - if you want to change styles in exisiting project you can use `ng set defaults.styleExt scss`
 
-- add below lines to angular.json: 
+- add below lines to angular.json:
 ```javascript
 "styles": [
     "node_modules/font-awesome/scss/font-awesome.scss",
@@ -205,47 +205,47 @@ Please read [CONTRIBUTING.md](https://github.com/mdbootstrap/Angular-Bootstrap-w
 
 # Highlights
 
-**Bootstrap 4**  
-Up-to-date with the latest standards of Bootstrap 4 and all the best it has to offer. 
+**Bootstrap 4**
+Up-to-date with the latest standards of Bootstrap 4 and all the best it has to offer.
 
-**Angular CLI**  
+**Angular CLI**
 A command line interface handling all the tedious tasks for you out of the box.
 
-**Detailed documentation**  
+**Detailed documentation**
 Intuitive and user-friendly documentation, created with a copy-paste approach.
 
-**No jQuery**  
-Writing you code with pure Angular is now quicker, easier, and cleaner. 
+**No jQuery**
+Writing you code with pure Angular is now quicker, easier, and cleaner.
 
-**TypeScript**  
-Superset of JavaScript that compiles to clean JavaScript output.  
+**TypeScript**
+Superset of JavaScript that compiles to clean JavaScript output.
 
-**Angular 7**  
-Create smarter and faster Angular apps with the latest official Angular release.  
+**Angular 8**
+Create smarter and faster Angular apps with the latest official Angular release.
 
-**Cross-browser compatibility**  
-Works perfectly with Chrome, Firefox, IE, Safari, Opera and Microsoft Edge.  
+**Cross-browser compatibility**
+Works perfectly with Chrome, Firefox, IE, Safari, Opera and Microsoft Edge.
 
-**Frequent updates**  
-Expect any bugs being fixed in a matter of days.   
+**Frequent updates**
+Expect any bugs being fixed in a matter of days.
 
-**Active community**  
+**Active community**
 MDB is broadly used by professionals on multiple levels, who are ready to aid you.
 
-**Modularity**  
-Use TypeScript modules to compile package adjusted yo your needs. 
+**Modularity**
+Use TypeScript modules to compile package adjusted yo your needs.
 
-**Useful helpers**  
+**Useful helpers**
 Reduce the frequency of highly repetitive declarations in your CSS.
 
-**Technical support**  
-Every day we help our users with their issues and problems.  
+**Technical support**
+Every day we help our users with their issues and problems.
 
-**SASS files**  
+**SASS files**
 Thought-out .scss files come in a compile-ready form.
 
-**Flexbox**  
-Full support of Flexbox layout system lets you forget about alignment issues.  
+**Flexbox**
+Full support of Flexbox layout system lets you forget about alignment issues.
 
 ### Support MDB developers
 
@@ -254,7 +254,7 @@ Full support of Flexbox layout system lets you forget about alignment issues.
 - Follow us on [Twitter](https://twitter.com/mdbootstrap)
 - Like our page on [Facebook](https://www.facebook.com/mdbootstrap)
 
-A big ❤️ **thank you to all our users** ❤️ who are working with us to improve the software. We wouldn't be where we are without you. 
+A big ❤️ **thank you to all our users** ❤️ who are working with us to improve the software. We wouldn't be where we are without you.
 
 
 # Useful Links
@@ -281,7 +281,7 @@ A big ❤️ **thank you to all our users** ❤️ who are working with us to im
 
 # Social Media
 
-[Twitter](https://twitter.com/MDBootstrap) 
+[Twitter](https://twitter.com/MDBootstrap)
 
 [Facebook](https://www.facebook.com/mdbootstrap)
 


### PR DESCRIPTION
The README still says Angular 7 in a few places, so I figured I'd update it to Angular 8 per f701f1c. Also, the [logo](https://mdbootstrap.com/img/Marketing/products/angular/mdb-free.jpg) still shows Angular 7.