### PR TITLE
Fix: Carousel SCSS arrow image paths changed to use $image-path variable

### DIFF
--- a/projects/angular-bootstrap-md/src/lib/assets/scss/core/_variables.scss
+++ b/projects/angular-bootstrap-md/src/lib/assets/scss/core/_variables.scss
@@ -173,8 +173,8 @@ $avatar-img-max-width: 100px !default;
 // Carousels
 $carousel-control-icon-width: 2.25rem !default;
 $carousel-control-icon-height: $carousel-control-icon-width !default;
-$carousel-control-prev-icon: url('../../img/svg/arrow_left.svg') !default;
-$carousel-control-next-icon: url('../../img/svg/arrow_right.svg') !default;
+$carousel-control-prev-icon: url('#{$image-path}/svg/arrow_left.svg') !default;
+$carousel-control-next-icon: url('#{$image-path}/svg/arrow_right.svg') !default;
 $carousel-indicators-width: 0.625rem !default;
 $carousel-indicators-height: $carousel-indicators-width !default;
 $carousel-indicators-border-radius: $border-radius-circle !default;

--- a/projects/angular-bootstrap-md/src/lib/assets/scss/core/msc/_carousel.scss
+++ b/projects/angular-bootstrap-md/src/lib/assets/scss/core/msc/_carousel.scss
@@ -1,9 +1,9 @@
 .carousel {
   .carousel-control-prev-icon {
-    background-image: url('../img/svg/arrow_left.svg') !important;
+    background-image: $carousel-control-prev-icon !important;
   }
 
   .carousel-control-next-icon {
-    background-image: url('../img/svg/arrow_right.svg') !important;
+    background-image: $carousel-control-next-icon !important;
   }
 }


### PR DESCRIPTION
**Bug:**
With the 8.0.0 update, the carousel scss included literal paths to the arrow images, which failed to build, when we wanted to use the scss from the styles.scss and not from the angular.json.

**Fix:**
Changed the image paths, to use the path variables (`$carousel-control-prev-icon`, `$carousel-control-next-icon`) (already present in the 8.0.0 version).
Changed the path variables (`$carousel-control-prev-icon`, `$carousel-control-next-icon`) to include the `$image-path` variable

The bug has been reported already by an other user: https://mdbootstrap.com/support/angular/build-errors/